### PR TITLE
issue-52: cascading bug fix from last release(1.5.4)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ in admin.
 
 Project aims to support 3.4+ and Django 2.0+.
 
-Current stable version is **1.5.4**.
+Current stable version is **1.5.5**.
 
 For **Django < 2.0** version support or **python-2.x** compatibility, please use version **1.3.4** which is
 the last version to support **python-2.x** compatibility.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 1.5.5
+-------------
+- Fixed cascading issue-52 bug
+- Introducing django's Jquery to easy-select2 for accessing django's JQuery
+
 Version 1.5.4
 -------------
 - Work with jQuery instead of depending on $, thanks to *leibowitz*

--- a/easy_select2/static/easy_select2/js/easy_select2.js
+++ b/easy_select2/static/easy_select2/js/easy_select2.js
@@ -11,7 +11,11 @@ if (window.$ == undefined) {
 }
 
 
-(function ($) {
+/**
+ * $ - external JQuery ref
+ * _djq - django Jquery ref
+ */
+(function ($, _djq) {
     "use strict";
     // store for keeping all the select2 widget ids for fail-safe parsing later
     var _all_easy_select2_ids = [];
@@ -86,7 +90,8 @@ if (window.$ == undefined) {
             }
         };
 
-        $(document).on('formset:added', function (event, $row, formsetName) {
+        // using django.jQuery for accessing django specific events
+        _djq(document).on('formset:added', function (event, $row, formsetName) {
             updateSelect($row);
         });
     }
@@ -99,4 +104,4 @@ if (window.$ == undefined) {
         add_select2_handlers(options);
     };
 
-}(jQuery || django.jQuery));
+}(jQuery || django.jQuery, django.jQuery));

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ class Tox(TestCommand):
 
 setup(
     name="django-easy-select2",
-    version="1.5.4",
+    version="1.5.5",
     packages=find_packages(),
     author="asyncee",
     description="Django select2 theme for select input widgets.",


### PR DESCRIPTION
Introducing django.jQuery to easy-select-2 for accessing django's Jquery functionalities, in particular to this fix, the events.

----
Hoping for a good coupling between django and easy-select2 ideologies(since easy-select2 was meant to be a simple wrapper around select2.js)