### PR TITLE
Add dependency on django admin jquery.init.js

### DIFF
--- a/easy_select2/widgets.py
+++ b/easy_select2/widgets.py
@@ -106,9 +106,12 @@ class Select2Mixin(object):
             id_, name, value, attrs=attrs, **kwargs)
         return mark_safe(output)
 
-    class Media:
-        css = SELECT2_WIDGET_CSS
-        js = SELECT2_WIDGET_JS
+    @property
+    def media(self):
+        return forms.Media(
+            css=SELECT2_WIDGET_CSS,
+            js=SELECT2_WIDGET_JS
+        )
 
 
 class Select2(Select2Mixin, forms.Select):

--- a/easy_select2/widgets.py
+++ b/easy_select2/widgets.py
@@ -27,6 +27,8 @@ SELECT2_WIDGET_JS = [
 if SELECT2_USE_BUNDLED_JQUERY:
     jquery_min_file = 'easy_select2/vendor/jquery/jquery.min.js'
     SELECT2_WIDGET_JS.insert(0, jquery_min_file)
+else:
+    SELECT2_WIDGET_JS.insert(0, 'admin/js/jquery.init.js')
 
 SELECT2_WIDGET_CSS = {
     'screen': [

--- a/easy_select2/widgets.py
+++ b/easy_select2/widgets.py
@@ -5,38 +5,6 @@ from django import forms
 from django.conf import settings
 from django.utils.safestring import mark_safe
 
-SELECT2_JS = getattr(
-        settings,
-        'SELECT2_JS',
-        'easy_select2/vendor/select2/js/select2.min.js',
-)
-SELECT2_CSS = getattr(
-        settings,
-        'SELECT2_CSS',
-        'easy_select2/vendor/select2/css/select2.min.css',
-)
-SELECT2_USE_BUNDLED_JQUERY = getattr(
-        settings, 'SELECT2_USE_BUNDLED_JQUERY', True)
-
-SELECT2_WIDGET_JS = [
-    'easy_select2/js/init.js',
-    'easy_select2/js/easy_select2.js',
-    SELECT2_JS,
-]
-
-if SELECT2_USE_BUNDLED_JQUERY:
-    jquery_min_file = 'easy_select2/vendor/jquery/jquery.min.js'
-    SELECT2_WIDGET_JS.insert(0, jquery_min_file)
-else:
-    SELECT2_WIDGET_JS.insert(0, 'admin/js/jquery.init.js')
-
-SELECT2_WIDGET_CSS = {
-    'screen': [
-        SELECT2_CSS,
-        'easy_select2/css/easy_select2.css',
-    ],
-}
-
 
 class Select2Mixin(object):
     """
@@ -67,7 +35,41 @@ class Select2Mixin(object):
         )
         if 'width' not in self.select2attrs:
             self.select2attrs.update({'width': '250px'})
+        self.static_settings()
         super(Select2Mixin, self).__init__(*args, **kwargs)
+
+    def static_settings(self):
+        SELECT2_JS = getattr(
+                settings,
+                'SELECT2_JS',
+                'easy_select2/vendor/select2/js/select2.min.js',
+        )
+        SELECT2_CSS = getattr(
+                settings,
+                'SELECT2_CSS',
+                'easy_select2/vendor/select2/css/select2.min.css',
+        )
+        SELECT2_USE_BUNDLED_JQUERY = getattr(
+                settings, 'SELECT2_USE_BUNDLED_JQUERY', True)
+
+        self.SELECT2_WIDGET_JS = [
+            'easy_select2/js/init.js',
+            'easy_select2/js/easy_select2.js',
+            SELECT2_JS,
+        ]
+
+        if SELECT2_USE_BUNDLED_JQUERY:
+            jquery_min_file = 'easy_select2/vendor/jquery/jquery.min.js'
+            self.SELECT2_WIDGET_JS.insert(0, jquery_min_file)
+        else:
+            self.SELECT2_WIDGET_JS.insert(0, 'admin/js/jquery.init.js')
+
+        self.SELECT2_WIDGET_CSS = {
+            'screen': [
+                SELECT2_CSS,
+                'easy_select2/css/easy_select2.css',
+            ],
+        }
 
     # This function is taken from django-select2
     def get_options(self):
@@ -109,8 +111,8 @@ class Select2Mixin(object):
     @property
     def media(self):
         return forms.Media(
-            css=SELECT2_WIDGET_CSS,
-            js=SELECT2_WIDGET_JS
+            css=self.SELECT2_WIDGET_CSS,
+            js=self.SELECT2_WIDGET_JS
         )
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -92,3 +92,9 @@ def test_staticfiles_url(settings):
                 settings.STATIC_URL,
                 v,
         )
+
+
+def test_select(settings):
+    settings.SELECT2_USE_BUNDLED_JQUERY = False
+    s = widgets.Select2Mixin()
+    assert s.SELECT2_WIDGET_JS[0] == 'admin/js/jquery.init.js'

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -75,8 +75,9 @@ def test_select2mixin_render(mocked):
 
 
 def test_staticfiles_url(settings):
-    js = widgets.SELECT2_WIDGET_JS
-    css = widgets.SELECT2_WIDGET_CSS
+    s = widgets.Select2Mixin()
+    js = s.SELECT2_WIDGET_JS
+    css = s.SELECT2_WIDGET_CSS
 
     def all_startswith(string, iterable):
         return all([staticfiles_storage.url(x).startswith(string)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -94,7 +94,7 @@ def test_staticfiles_url(settings):
         )
 
 
-def test_select(settings):
+def test_django_jquery(settings):
     settings.SELECT2_USE_BUNDLED_JQUERY = False
     s = widgets.Select2Mixin()
     assert s.media._js[0] == 'admin/js/jquery.init.js'

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -76,8 +76,8 @@ def test_select2mixin_render(mocked):
 
 def test_staticfiles_url(settings):
     s = widgets.Select2Mixin()
-    js = s.SELECT2_WIDGET_JS
-    css = s.SELECT2_WIDGET_CSS
+    js = s.media._js
+    css = s.media._css
 
     def all_startswith(string, iterable):
         return all([staticfiles_storage.url(x).startswith(string)
@@ -97,4 +97,4 @@ def test_staticfiles_url(settings):
 def test_select(settings):
     settings.SELECT2_USE_BUNDLED_JQUERY = False
     s = widgets.Select2Mixin()
-    assert s.SELECT2_WIDGET_JS[0] == 'admin/js/jquery.init.js'
+    assert s.media._js[0] == 'admin/js/jquery.init.js'


### PR DESCRIPTION
When setting `SELECT2_USE_BUNDLED_JQUERY = False`, the order of scripts being loaded seems to lead to issues in some instances.

The error I get:
> select2.min.js:1 Select2: An instance of jQuery or a jQuery-compatible library was not found. Make sure that you are including jQuery before Select2 on your web page.
> select2.min.js:2 Uncaught TypeError: Cannot read property 'fn' of undefined

This is only a problem since django 2.2+, due to a change in the sorting of media assets in django:
> ### Merging of form Media assets
> Form **Media** assets are now merged using a topological sort algorithm, as the old pairwise merging algorithm is insufficient for some cases. CSS and JavaScript files which don’t include their dependencies may now be sorted incorrectly (where the old algorithm produced results correctly by coincidence).
>
> Audit all **Media** classes for any missing dependencies. For example, widgets depending on **django.jQuery** must specify **js=['admin/js/jquery.init.js', ...]** when [declaring form media assets](https://docs.djangoproject.com/en/3.0/topics/forms/media/#assets-as-a-static-definition).

Source: https://docs.djangoproject.com/en/3.0/releases/2.2/#merging-of-form-media-assets

As the doc specifies, adding `admin/js/jquery.init.js` seems to fix the issue