### PR TITLE
GitHub Actions: Get off deprecated ::set-env

### DIFF
--- a/.github/workflows/run_pre_commit.yml
+++ b/.github/workflows/run_pre_commit.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Install pre-commit
         run: |-
+          set -e
           pip install \
             --disable-pip-version-check \
             --user \

--- a/.github/workflows/run_pre_commit.yml
+++ b/.github/workflows/run_pre_commit.yml
@@ -26,7 +26,7 @@ jobs:
             --user \
             --no-warn-script-location \
             pre-commit
-          echo "::set-env name=PATH::${HOME}/.local/bin:${PATH}"
+          echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"
 
       - name: Install pre-commit hooks
         run: |-


### PR DESCRIPTION
Related:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/