### PR TITLE
Fix coveralls integration / tox.ini: Take away GITHUB_ACTIONS from coveralls

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,16 @@ deps =
 commands =
     coverage run --source easy_select2 -m py.test tests
     coverage report -m
-    bash -c 'set -x; [[ $\{GITHUB_ACTIONS:-false\} = false ]] || coveralls'
+    bash -c 'set -x; [[ -z $\{COVERALLS_REPO_TOKEN\} ]] || coveralls'
 setenv = {[base]setenv}
+# not GITHUB_ACTIONS!
+# not GITHUB_TOKEN!
 passenv =
     COVERALLS_REPO_TOKEN
-    GITHUB_*
+    GITHUB_HEAD_REF
+    GITHUB_REF
+    GITHUB_REPOSITORY
+    GITHUB_RUN_ID
+    GITHUB_RUN_NUMBER
+    GITHUB_SHA
 allowlist_externals = bash


### PR DESCRIPTION
.. so that it stops complaining about missing variable `GITHUB_TOKEN` ..

> Running on Github Actions but GITHUB_TOKEN is not set.
> Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to
> your step config.

(which may have write access) and that we stopped sharing with coveralls in PR #97.

The related code checks for presence of variable `GITHUB_ACTIONS` so we we take that variable from coveralls-python.

Rather than excluding variable `GITHUB_ACTIONS`, we include all other `GITHUB_*` variables used by coveralls-python.  The list was derive like this:

```console
$ git clone --depth 1 https://github.com/TheKevJames/coveralls-python
$ cd coveralls-python/
$ git grep -oh "GITHUB_[^ ':\`*]\+" | sort -u
GITHUB_ACTIONS
GITHUB_HEAD_REF
GITHUB_REF
GITHUB_REPOSITORY
GITHUB_RUN_ID
GITHUB_RUN_NUMBER
GITHUB_SHA
GITHUB_TOKEN
```

PS: In reaction to https://github.com/asyncee/django-easy-select2/runs/5087340885?check_suite_focus=true#step:5:154

CC @asyncee (I'll dare to merge now)