### PR TITLE
Pin GitHub Actions to specific commits for security

### DIFF
--- a/.github/workflows/run_pre_commit.yml
+++ b/.github/workflows/run_pre_commit.yml
@@ -14,10 +14,10 @@ jobs:
     name: Run pre-commit on all files
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -22,10 +22,10 @@ jobs:
           - '3.10'  # includes tox env about code coverage
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
For proof that GitHub Dependabot can still keep things up to date for us with the new format see https://github.com/gentoo-ev/www.gentoo-ev.org/pull/5/files .