### PR TITLE
Get CI off of about-to-be-removed Ubuntu 20.04 + drop EOL Python 3.7. and 3.8

### DIFF
--- a/.github/workflows/run_pre_commit.yml
+++ b/.github/workflows/run_pre_commit.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   run_pre_commit:
     name: Run pre-commit on all files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   run_tox:
     name: Run tox
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -16,9 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7  # oldest supported version
-        # - 3.8  # no particial need
-        # - 3.9  # no particial need
+          - 3.9  # oldest supported version
           - '3.10'  # includes tox env about code coverage
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ in admin.
 |python| |pypi| |github-actions| |coveralls| |license|
 
 
-Project aims to support Python 3.7+ and Django 2.2+.
+Project aims to support Python 3.9+ and Django 2.2+.
 
 For **Django < 2.0** version support or **python-2.x** compatibility, please use version **1.3.4** which is
 the last version to support **python-2.x** compatibility.

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     url='https://github.com/asyncee/django-easy-select2',
     download_url='https://pypi.python.org/pypi/django-easy-select2/',
 
-    python_requires='>=3.7',
+    python_requires='>=3.9',
     install_requires=[
         'Django>=2.2',
     ],
@@ -66,8 +66,6 @@ setup(
           'Programming Language :: Python',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3 :: Only',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
           'Topic :: Software Development :: Widget Sets',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # No particular need for Python 3.8 and 3.9
 envlist =
-    py37-django22,
+    py39-django22,
     py310-{django32,django40,coverage},
 
 [base]


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/11101